### PR TITLE
feat: add job preview and AI generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
@@ -21,6 +22,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "eslint": "^9",
-    "eslint-config-next": "15.5.2"
+    "eslint-config-next": "15.5.2",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/app/api/generate-job/route.js
+++ b/src/app/api/generate-job/route.js
@@ -1,0 +1,67 @@
+import { NextResponse } from 'next/server';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+export const runtime = 'nodejs';
+
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+
+export async function POST(request) {
+  try {
+    const { target, keywords, context } = await request.json();
+
+    if (!keywords) {
+      return NextResponse.json(
+        { error: 'キーワードが入力されていません。' },
+        { status: 400 }
+      );
+    }
+
+    const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
+
+    const workHistoryText = context?.histories
+      ?.filter((h) => h.type === 'entry' && h.description)
+      ?.map((h) => `${h.year}年${h.month}月 ${h.description}`)
+      ?.join('\n') || '記載なし';
+
+    let prompt = '';
+    if (target === 'summary') {
+      prompt = `
+        あなたは優秀なキャリアアドバイザーです。
+        以下の職務経歴を基に、日本の就職活動向けの「職務要約」を200字程度で作成してください。
+
+        # 職務経歴
+        ${workHistoryText}
+
+        # キーワード
+        ${keywords}
+      `;
+    } else {
+      prompt = `
+        あなたは優秀なキャリアアドバイザーです。
+        以下の職務経歴を基に、日本の就職活動向けの「職務経歴詳細」を300〜400字程度で作成してください。
+
+        # 職務経歴
+        ${workHistoryText}
+
+        # キーワード
+        ${keywords}
+      `;
+    }
+
+    const result = await model.generateContent(prompt);
+    const response = await result.response;
+    const generatedText = response.text();
+
+    return NextResponse.json({
+      jobSummary: target === 'summary' ? generatedText : '',
+      jobDetails: target === 'detail' ? generatedText : '',
+    });
+  } catch (error) {
+    console.error('Gemini APIエラー:', error);
+    return NextResponse.json(
+      { error: 'AI文章の生成中にエラーが発生しました。' },
+      { status: 500 }
+    );
+  }
+}
+

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -340,6 +340,9 @@ body {
 .ai-generate-btn:disabled { background-color: #ccc; cursor: not-allowed; }
 .ai-error-message { width: 100%; color: #dc3545; font-size: 12px; margin: 0; }
 
+/* JobPreview */
+.job-preview .free-text-grid .f-content { min-height: 120px; }
+
 /* 学歴欄の内側編集 div（免許欄に合わせ） */
 .h-desc-input[contentEditable="true"] {
   outline: none;

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState, useId } from 'react';
 import { useReactToPrint } from 'react-to-print';
 import ResumePreview from '@/components/ResumePreview';
+import JobPreview from '@/components/JobPreview';
 import { useResumeStore } from '@/store/resumeStore';
 
 export default function Home() {
@@ -13,6 +14,7 @@ export default function Home() {
   const { updatePhotoUrl } = useResumeStore();
 
   const [isReady, setIsReady] = useState(false);
+  const [view, setView] = useState('resume');
   useEffect(() => {
     // 画面に出たら有効化
     if (contentRef.current) setIsReady(true);
@@ -77,12 +79,24 @@ export default function Home() {
           >
             {isReady ? 'PDFダウンロード' : '準備中...'}
           </button>
+
+          <button
+            type="button"
+            className="download-btn"
+            onClick={() => setView(view === 'resume' ? 'job' : 'resume')}
+          >
+            {view === 'resume' ? '職務経歴書へ' : '履歴書へ'}
+          </button>
         </div>
       </header>
 
       {/* 印刷対象 */}
       <div style={{ display: 'flex', justifyContent: 'center' }}>
-        <ResumePreview ref={contentRef} />
+        {view === 'resume' ? (
+          <ResumePreview ref={contentRef} />
+        ) : (
+          <JobPreview ref={contentRef} />
+        )}
       </div>
     </main>
   );

--- a/src/components/JobPreview.js
+++ b/src/components/JobPreview.js
@@ -1,0 +1,136 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useResumeStore } from '@/store/resumeStore';
+
+const JobPreview = React.forwardRef((props, ref) => {
+  const {
+    histories,
+    jobSummary,
+    jobDetails,
+    updateJobSummary,
+    updateJobDetails,
+  } = useResumeStore();
+
+  const [summaryKeywords, setSummaryKeywords] = useState('');
+  const [detailKeywords, setDetailKeywords] = useState('');
+  const [isSummaryGenerating, setIsSummaryGenerating] = useState(false);
+  const [isDetailGenerating, setIsDetailGenerating] = useState(false);
+  const [summaryError, setSummaryError] = useState('');
+  const [detailError, setDetailError] = useState('');
+
+  const handleGenerate = async (
+    target,
+    keywords,
+    setError,
+    setLoading,
+    updater
+  ) => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/generate-job', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target, keywords, context: { histories } }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || 'AIの生成に失敗しました。');
+      }
+      const data = await res.json();
+      if (target === 'summary') updater(data.jobSummary || '');
+      if (target === 'detail') updater(data.jobDetails || '');
+    } catch (e) {
+      setError(e.message || 'エラーが発生しました');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="resume-container job-preview" ref={ref}>
+      <div className="free-text-grid">
+        <div className="cell f-header">職務要約</div>
+        <div
+          className="cell f-content"
+          contentEditable
+          suppressContentEditableWarning
+          onBlur={(e) => updateJobSummary(e.currentTarget.innerText)}
+          data-placeholder="これまでの経験を簡潔にまとめてください"
+        >
+          {jobSummary}
+        </div>
+        <div className="ai-controls">
+          <input
+            type="text"
+            value={summaryKeywords}
+            onChange={(e) => setSummaryKeywords(e.target.value)}
+            placeholder="要約に入れたいキーワード"
+            className="ai-keyword-input"
+            disabled={isSummaryGenerating}
+          />
+          <button
+            onClick={() =>
+              handleGenerate(
+                'summary',
+                summaryKeywords,
+                setSummaryError,
+                setIsSummaryGenerating,
+                updateJobSummary
+              )
+            }
+            className="ai-generate-btn"
+            disabled={isSummaryGenerating || !summaryKeywords}
+          >
+            {isSummaryGenerating ? '生成中...' : 'AIで要約生成'}
+          </button>
+          {summaryError && <p className="ai-error-message">{summaryError}</p>}
+        </div>
+      </div>
+
+      <div className="free-text-grid" style={{ marginTop: '20px' }}>
+        <div className="cell f-header">職務経歴詳細</div>
+        <div
+          className="cell f-content"
+          contentEditable
+          suppressContentEditableWarning
+          onBlur={(e) => updateJobDetails(e.currentTarget.innerText)}
+          data-placeholder="職務内容を詳しく記載してください"
+        >
+          {jobDetails}
+        </div>
+        <div className="ai-controls">
+          <input
+            type="text"
+            value={detailKeywords}
+            onChange={(e) => setDetailKeywords(e.target.value)}
+            placeholder="詳細に入れたいキーワード"
+            className="ai-keyword-input"
+            disabled={isDetailGenerating}
+          />
+          <button
+            onClick={() =>
+              handleGenerate(
+                'detail',
+                detailKeywords,
+                setDetailError,
+                setIsDetailGenerating,
+                updateJobDetails
+              )
+            }
+            className="ai-generate-btn"
+            disabled={isDetailGenerating || !detailKeywords}
+          >
+            {isDetailGenerating ? '生成中...' : 'AIで詳細生成'}
+          </button>
+          {detailError && <p className="ai-error-message">{detailError}</p>}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+JobPreview.displayName = 'JobPreview';
+export default JobPreview;
+

--- a/src/store/resumeStore.js
+++ b/src/store/resumeStore.js
@@ -27,6 +27,8 @@ const initialResumeData = {
   motivation: '',
   selfPromotion: '',
   requests: '',
+  jobSummary: '',
+  jobDetails: '',
 
   // 証明写真（Base64 Data URL を想定）
   photoUrl: '',
@@ -106,6 +108,8 @@ export const useResumeStore = create(
       updateMotivation: (value) => set({ motivation: value }),
       updateSelfPromotion: (value) => set({ selfPromotion: value }),
       updateRequests: (value) => set({ requests: value }),
+      updateJobSummary: (value) => set({ jobSummary: value }),
+      updateJobDetails: (value) => set({ jobDetails: value }),
 
       // --- photo
       updatePhotoUrl: (dataUrl) => set({ photoUrl: dataUrl }),

--- a/src/store/resumeStore.test.js
+++ b/src/store/resumeStore.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { useResumeStore } from './resumeStore';
+
+describe('resumeStore job fields', () => {
+  it('updates job summary and details', () => {
+    const { updateJobSummary, updateJobDetails } = useResumeStore.getState();
+    updateJobSummary('summary');
+    updateJobDetails('details');
+    const { jobSummary, jobDetails } = useResumeStore.getState();
+    expect(jobSummary).toBe('summary');
+    expect(jobDetails).toBe('details');
+  });
+});


### PR DESCRIPTION
## Summary
- add JobPreview component with AI generation controls
- add /api/generate-job route for job summaries and details
- extend Zustand store and toggle view on home page

## Testing
- `pnpm build` *(fails: next not found)*
- `pnpm test` *(fails: vitest not found)*
- `pnpm lint` *(fails: cannot find @eslint/eslintrc)*

------
https://chatgpt.com/codex/tasks/task_e_68c113d74b748329abfbecb92cc55d9a