### PR TITLE
feat: add job preview and AI draft generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
@@ -21,6 +22,7 @@
   "devDependencies": {
     "@eslint/eslintrc": "^3",
     "eslint": "^9",
-    "eslint-config-next": "15.5.2"
+    "eslint-config-next": "15.5.2",
+    "vitest": "^1.6.0"
   }
 }

--- a/src/app/api/generate-job/route.js
+++ b/src/app/api/generate-job/route.js
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+export const runtime = 'nodejs';
+
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+
+export async function POST(request) {
+  try {
+    const { keywords, context = {}, pattern } = await request.json();
+    if (!keywords) {
+      return NextResponse.json({ error: 'キーワードが入力されていません。' }, { status: 400 });
+    }
+    const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
+    const histories = context.histories || [];
+    const historyText = histories
+      .filter((h) => h.type === 'entry' && h.description)
+      .map((h) => `${h.year}年${h.month}月 ${h.description}`)
+      .join('\n');
+    const prompt = `あなたは優秀なキャリアアドバイザーです。\n以下の情報を基に「職務経歴要約」を作成してください。\n\n# 職務経歴\n${historyText || '記載なし'}\n\n# キーワード\n${keywords}\n\n# パターン\n${pattern || 'default'}`;
+    const result = await model.generateContent(prompt);
+    const generatedText = await result.response.text();
+    return NextResponse.json({ generatedText });
+  } catch (error) {
+    console.error('Gemini APIエラー:', error);
+    return NextResponse.json(
+      { error: 'AI文章の生成中にエラーが発生しました。' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -319,6 +319,12 @@ body {
   gap: 10px;
   align-items: center;
 }
+
+.job-preview { margin-top: 40px; }
+
+@media print {
+  .job-preview { page-break-before: always; }
+}
 .ai-keyword-input {
   flex-grow: 1;
   padding: 8px 12px;

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState, useId } from 'react';
 import { useReactToPrint } from 'react-to-print';
 import ResumePreview from '@/components/ResumePreview';
+import JobPreview from '@/components/JobPreview';
 import { useResumeStore } from '@/store/resumeStore';
 
 export default function Home() {
@@ -82,7 +83,10 @@ export default function Home() {
 
       {/* 印刷対象 */}
       <div style={{ display: 'flex', justifyContent: 'center' }}>
-        <ResumePreview ref={contentRef} />
+        <div ref={contentRef}>
+          <ResumePreview />
+          <JobPreview />
+        </div>
       </div>
     </main>
   );

--- a/src/components/JobPreview.js
+++ b/src/components/JobPreview.js
@@ -1,0 +1,101 @@
+// src/components/JobPreview.js
+'use client';
+
+import React, { useState } from 'react';
+import { useResumeStore } from '@/store/resumeStore';
+
+const JobPreview = React.forwardRef((props, ref) => {
+  const {
+    jobSummary,
+    jobDetails,
+    histories,
+    licenses,
+    profile,
+    updateJobSummary,
+    updateJobDetails,
+  } = useResumeStore();
+
+  const [keywords, setKeywords] = useState('');
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [aiError, setAiError] = useState('');
+
+  const handleGenerateSummary = async () => {
+    setIsGenerating(true);
+    setAiError('');
+    try {
+      const res = await fetch('/api/generate-job', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          keywords,
+          context: { histories, licenses, profile },
+        }),
+      });
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}));
+        throw new Error(err.error || 'AIの生成に失敗しました。');
+      }
+      const data = await res.json();
+      updateJobSummary(data.generatedText || '');
+    } catch (e) {
+      setAiError(e.message || 'エラーが発生しました');
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
+  return (
+    <div className="resume-container job-preview" ref={ref}>
+      <div className="title-row">
+        <h1>職務経歴書</h1>
+      </div>
+
+      <div className="free-text-grid">
+        <div className="cell f-header">職務経歴要約</div>
+        <div
+          className="cell f-content"
+          contentEditable
+          suppressContentEditableWarning
+          onBlur={(e) => updateJobSummary(e.currentTarget.innerText)}
+          data-placeholder="これまでの経験を簡潔にまとめましょう"
+        >
+          {jobSummary}
+        </div>
+        <div className="ai-controls">
+          <input
+            type="text"
+            value={keywords}
+            onChange={(e) => setKeywords(e.target.value)}
+            placeholder="要約に入れたいキーワード"
+            className="ai-keyword-input"
+            disabled={isGenerating}
+          />
+          <button
+            onClick={handleGenerateSummary}
+            className="ai-generate-btn"
+            disabled={isGenerating || !keywords}
+          >
+            {isGenerating ? '生成中...' : 'AIで要約を生成'}
+          </button>
+          {aiError && <p className="ai-error-message">{aiError}</p>}
+        </div>
+      </div>
+
+      <div className="free-text-grid" style={{ marginTop: 20 }}>
+        <div className="cell f-header">職務経歴詳細</div>
+        <div
+          className="cell f-content"
+          contentEditable
+          suppressContentEditableWarning
+          onBlur={(e) => updateJobDetails(e.currentTarget.innerText)}
+          data-placeholder="詳細な業務内容を記載しましょう"
+        >
+          {jobDetails}
+        </div>
+      </div>
+    </div>
+  );
+});
+
+JobPreview.displayName = 'JobPreview';
+export default JobPreview;

--- a/src/store/resumeStore.js
+++ b/src/store/resumeStore.js
@@ -27,6 +27,8 @@ const initialResumeData = {
   motivation: '',
   selfPromotion: '',
   requests: '',
+  jobSummary: '',
+  jobDetails: '',
 
   // 証明写真（Base64 Data URL を想定）
   photoUrl: '',
@@ -106,6 +108,8 @@ export const useResumeStore = create(
       updateMotivation: (value) => set({ motivation: value }),
       updateSelfPromotion: (value) => set({ selfPromotion: value }),
       updateRequests: (value) => set({ requests: value }),
+      updateJobSummary: (value) => set({ jobSummary: value }),
+      updateJobDetails: (value) => set({ jobDetails: value }),
 
       // --- photo
       updatePhotoUrl: (dataUrl) => set({ photoUrl: dataUrl }),

--- a/src/store/resumeStore.test.js
+++ b/src/store/resumeStore.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockStorage = (() => {
+  let store = {};
+  return {
+    getItem: (key) => (key in store ? store[key] : null),
+    setItem: (key, value) => {
+      store[key] = value;
+    },
+    removeItem: (key) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+vi.stubGlobal('localStorage', mockStorage);
+
+const { useResumeStore } = await import('./resumeStore');
+
+beforeEach(() => {
+  useResumeStore.setState({ jobSummary: '', jobDetails: '' });
+});
+
+describe('resumeStore job fields', () => {
+  it('updates job summary and details', () => {
+    const { updateJobSummary, updateJobDetails } = useResumeStore.getState();
+    updateJobSummary('summary');
+    updateJobDetails('details');
+    const state = useResumeStore.getState();
+    expect(state.jobSummary).toBe('summary');
+    expect(state.jobDetails).toBe('details');
+  });
+});


### PR DESCRIPTION
## Purpose
- add JobPreview component and AI draft API

## Changes
- extend store with job fields and updaters
- add JobPreview UI and /api/generate-job route
- integrate into page and styles
- add basic store unit test

## Impact
- enables job resume editing and draft generation alongside existing resume

## Rollback
- revert commit 671c004a58ed0f1cbda5f790689105b38f25ed49

## Test
- `pnpm build` *(failed: Failed to fetch `Geist` from Google Fonts)*
- `pnpm test` *(failed: vitest: not found)*
- `pnpm lint` *(warn: Using `<img>` could result in slower LCP and higher bandwidth)*


------
https://chatgpt.com/codex/tasks/task_e_68c14547fd908329a8973cab07fa5bdd