### PR TITLE
fix: handle job generation response

### DIFF
--- a/src/app/api/generate-job/route.test.js
+++ b/src/app/api/generate-job/route.test.js
@@ -2,13 +2,20 @@ import { describe, it, expect } from 'vitest';
 import { POST } from './route';
 
 describe('generate-job API', () => {
-  it('returns 500 when API key missing', async () => {
+  it('returns structured error when API key missing', async () => {
     const req = new Request('http://localhost', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ keywords: 'test', histories: [] }),
+      body: JSON.stringify({ keywords: 'test', context: { histories: [] } }),
     });
     const res = await POST(req);
     expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json).toEqual({
+      ok: false,
+      summary: '',
+      details: [],
+      error: 'Gemini APIキーが未設定です',
+    });
   });
 });

--- a/src/store/resumeStore.js
+++ b/src/store/resumeStore.js
@@ -110,11 +110,14 @@ export const useResumeStore = create(
       updateSelfPromotion: (value) => set({ selfPromotion: value }),
       updateRequests: (value) => set({ requests: value }),
       // ▼ 職務経歴書 用のupdate
-      updateJobSummary: (value) => set({ jobSummary: value }),
-      setJobDetails: (arr) => set({ jobDetails: arr }),
-      updateJobDetail: (index, value) =>
+      setJobSummary: (value) => set({ jobSummary: value }),
+      setJobDetails: (arr) =>
+        set({ jobDetails: Array.isArray(arr) ? arr : [] }),
+      upsertJobDetail: (index, value) =>
         set((state) => {
-          const next = [...(state.jobDetails || [])];
+          const next = Array.isArray(state.jobDetails)
+            ? [...state.jobDetails]
+            : [];
           next[index] = value;
           return { jobDetails: next };
         }),

--- a/src/store/resumeStore.test.js
+++ b/src/store/resumeStore.test.js
@@ -26,10 +26,11 @@ beforeEach(() => {
 
 describe('resumeStore job fields', () => {
   it('updates job summary and details array', () => {
-    const { updateJobSummary, setJobDetails, updateJobDetail } = useResumeStore.getState();
-    updateJobSummary('summary');
+    const { setJobSummary, setJobDetails, upsertJobDetail } =
+      useResumeStore.getState();
+    setJobSummary('summary');
     setJobDetails(['a', 'b']);
-    updateJobDetail(1, 'updated');
+    upsertJobDetail(1, 'updated');
     const state = useResumeStore.getState();
     expect(state.jobSummary).toBe('summary');
     expect(state.jobDetails).toEqual(['a', 'updated']);


### PR DESCRIPTION
## 目的
- 職務経歴書のAI生成結果がストアに反映されない不具合を修正

## 変更点
- Zustandストアに`setJobSummary`/`setJobDetails`/`upsertJobDetail`を追加
- `/api/generate-job`を `{ ok, summary, details }` 形式で返すよう統一
- JobPreviewでAPI応答のフォールバックとエラーハンドリングを追加
- 既存ユニットテストを更新

## 影響範囲
- 職務経歴書生成機能
- `/api/generate-job` ルート

## ロールバック手順
- `git revert 8b6cfd9`

## テスト結果
- `pnpm build` : フォント取得失敗でエラー
- `pnpm lint` : ✖ 0 errors, 1 warning
- `pnpm test` : vitest 未インストール


------
https://chatgpt.com/codex/tasks/task_e_68c16adcf7bc83299b39e7afafb18d67