### PR TITLE
fix: update gemini model reference

### DIFF
--- a/src/app/api/generate-text/route.js
+++ b/src/app/api/generate-text/route.js
@@ -16,7 +16,7 @@ export async function POST(request) {
     }
 
     // モデルを選択
-    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash" });
+    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest" });
 
     // 職歴情報を整形
     const workHistoryText = context.histories


### PR DESCRIPTION
目的: Gemini APIコールの404エラーを解消し、生成処理を継続できるようにする。
影響範囲: AI自己PR生成API(`/api/generate-text`)
触るファイル: src/app/api/generate-text/route.js

## 変更点
- Geminiモデル指定を`gemini-1.5-flash`から`gemini-1.5-flash-latest`に更新

## 影響範囲
- Gemini APIへの文章生成リクエスト

## ロールバック手順
- `src/app/api/generate-text/route.js`内のモデル名を元の`gemini-1.5-flash`に戻す

## テスト結果
- lint: 失敗（依存パッケージ`@eslint/eslintrc`がインストールされておらずESLintが実行不可）

------
https://chatgpt.com/codex/tasks/task_e_68db911b3f8483298e679e3d1ad31a9f