### PR TITLE
fix: switch gemini model to stable variant

### DIFF
--- a/src/app/api/generate-text/route.js
+++ b/src/app/api/generate-text/route.js
@@ -16,7 +16,7 @@ export async function POST(request) {
     }
 
     // モデルを選択
-    const model = genAI.getGenerativeModel({ model: "gemini-1.5-flash-latest" });
+    const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
 
     // 職歴情報を整形
     const workHistoryText = context.histories

--- a/src/app/api/generate-text/route.test.js
+++ b/src/app/api/generate-text/route.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('next/server', () => ({
+  NextResponse: {
+    json: (data, init) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+vi.mock('@google/generative-ai', () => {
+  const generateContentMock = vi.fn().mockResolvedValue({
+    response: {
+      text: () => 'mocked text',
+    },
+  });
+  const getGenerativeModelMock = vi.fn(() => ({
+    generateContent: generateContentMock,
+  }));
+  class GoogleGenerativeAI {
+    constructor() {
+      this.getGenerativeModel = getGenerativeModelMock;
+    }
+  }
+  return {
+    GoogleGenerativeAI,
+    getGenerativeModelMock,
+  };
+});
+
+describe('generate-text API route', () => {
+  it('uses gemini-pro model when generating text', async () => {
+    process.env.GEMINI_API_KEY = 'test-key';
+    const { POST } = await import('./route');
+    const { getGenerativeModelMock } = await import('@google/generative-ai');
+
+    const request = new Request('http://localhost', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        keywords: 'teamwork',
+        context: { histories: [] },
+      }),
+    });
+
+    const response = await POST(request);
+    expect(getGenerativeModelMock).toHaveBeenCalledWith({ model: 'gemini-pro' });
+    expect(response.status).toBe(200);
+    const json = await response.json();
+    expect(json).toEqual({ generatedText: 'mocked text' });
+  });
+});


### PR DESCRIPTION
目的: GCPリージョン差異により404となるモデル指定を回避し、安定運用を確保する。
影響範囲: Gemini APIを利用する生成系APIルートとそのユニットテスト。
触るファイル: src/app/api/generate-text/route.js, src/app/api/generate-text/route.test.js

## 変更点
- 生成APIルートのモデル指定をgemini-proへ変更。
- ルートが安定モデルを利用することを確認するユニットテストを追加。

## 影響範囲
- Gemini API呼び出しの安定性が向上する一方で、レスポンス特性が変更される可能性があります。

## ロールバック手順
- `git revert <commit>` で本変更を取り消し、再デプロイしてください。

## テスト結果
- `pnpm test` : 失敗 (vitest未インストール: レジストリアクセスが403でブロック)


------
https://chatgpt.com/codex/tasks/task_e_68db93681b208329aedcfdbd5cee8a8f