### PR TITLE
fix: replace generate-text route Gemini call with fetch

### DIFF
--- a/src/app/api/generate-text/route.js
+++ b/src/app/api/generate-text/route.js
@@ -1,25 +1,27 @@
 import { NextResponse } from 'next/server';
-// Google AI SDKをインポート
-import { GoogleGenerativeAI } from '@google/generative-ai';
 
-// Geminiクライアントを初期化
-const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY);
+const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent';
+
+const extractTextFromCandidates = (candidates = []) =>
+  candidates
+    .flatMap(candidate => candidate?.content?.parts ?? [])
+    .map(part => part?.text ?? '')
+    .join('')
+    .trim();
 
 // POSTリクエストを処理する関数
 export async function POST(request) {
   try {
     // リクエストボディからキーワードと職歴コンテキストを取得
-    const { keywords, context } = await request.json();
+    const { keywords, context = {} } = await request.json();
 
     if (!keywords) {
       return NextResponse.json({ error: 'キーワードが入力されていません。' }, { status: 400 });
     }
 
-    // モデルを選択
-    const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
-
     // 職歴情報を整形
-    const workHistoryText = context.histories
+    const histories = Array.isArray(context?.histories) ? context.histories : [];
+    const workHistoryText = histories
       .filter(h => h.type === 'entry' && h.description)
       .map(h => `${h.year}年${h.month}月 ${h.description}`)
       .join('\n');
@@ -36,11 +38,41 @@ export async function POST(request) {
       ${keywords}
     `;
 
-    // Gemini APIを呼び出して文章を生成
-    const result = await model.generateContent(prompt);
-    const response = await result.response;
-    const generatedText = response.text();
-    
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json(
+        { error: 'Gemini APIキーが未設定です。' },
+        { status: 500 }
+      );
+    }
+
+    const response = await fetch(`${GEMINI_API_URL}?key=${apiKey}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        contents: [
+          {
+            role: 'user',
+            parts: [{ text: prompt }],
+          },
+        ],
+      }),
+    });
+
+    const payload = await response.json().catch(() => null);
+
+    if (!response.ok) {
+      console.error('Gemini APIエラー:', payload?.error?.message ?? response.statusText);
+      return NextResponse.json(
+        { error: 'AI文章の生成中にエラーが発生しました。' },
+        { status: 500 }
+      );
+    }
+
+    const generatedText = extractTextFromCandidates(payload?.candidates);
+
     // 生成されたテキストをクライアントに返す
     return NextResponse.json({ generatedText });
 

--- a/src/app/api/generate-text/route.test.js
+++ b/src/app/api/generate-text/route.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 vi.mock('next/server', () => ({
   NextResponse: {
@@ -9,31 +9,37 @@ vi.mock('next/server', () => ({
   },
 }));
 
-vi.mock('@google/generative-ai', () => {
-  const generateContentMock = vi.fn().mockResolvedValue({
-    response: {
-      text: () => 'mocked text',
-    },
-  });
-  const getGenerativeModelMock = vi.fn(() => ({
-    generateContent: generateContentMock,
-  }));
-  class GoogleGenerativeAI {
-    constructor() {
-      this.getGenerativeModel = getGenerativeModelMock;
-    }
-  }
-  return {
-    GoogleGenerativeAI,
-    getGenerativeModelMock,
-  };
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  global.fetch = vi.fn();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  delete process.env.GEMINI_API_KEY;
+  vi.resetModules();
 });
 
 describe('generate-text API route', () => {
   it('uses gemini-pro model when generating text', async () => {
     process.env.GEMINI_API_KEY = 'test-key';
     const { POST } = await import('./route');
-    const { getGenerativeModelMock } = await import('@google/generative-ai');
+
+    const mockJson = vi.fn().mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [{ text: 'mocked text' }],
+          },
+        },
+      ],
+    });
+
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: mockJson,
+    });
 
     const request = new Request('http://localhost', {
       method: 'POST',
@@ -45,7 +51,24 @@ describe('generate-text API route', () => {
     });
 
     const response = await POST(request);
-    expect(getGenerativeModelMock).toHaveBeenCalledWith({ model: 'gemini-pro' });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const fetchCall = global.fetch.mock.calls[0];
+    expect(fetchCall[0]).toBe(
+      'https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent?key=test-key'
+    );
+    const body = JSON.parse(fetchCall[1].body);
+    expect(body).toEqual({
+      contents: [
+        {
+          role: 'user',
+          parts: [
+            {
+              text: expect.stringContaining('アピールしたいキーワード'),
+            },
+          ],
+        },
+      ],
+    });
     expect(response.status).toBe(200);
     const json = await response.json();
     expect(json).toEqual({ generatedText: 'mocked text' });


### PR DESCRIPTION
## 目的 / 影響範囲 / 触るファイル
- 目的: Gemini API 呼び出しを安定版 v1 エンドポイントへ切り替えて 404 エラーを解消する
- 影響範囲: 自己PR生成 API (`/api/generate-text`)、同ルートの単体テスト
- 触るファイル: `src/app/api/generate-text/route.js`, `src/app/api/generate-text/route.test.js`

## 変更点
- Google Generative AI SDK の利用を廃止し、`fetch` で `v1/models/gemini-pro:generateContent` を直接叩くよう更新
- API キー未設定・Gemini 応答エラー時のハンドリングを強化
- 新しいリクエスト形式に合わせて単体テストを更新し、`fetch` 呼び出し内容を検証

## 影響範囲
- `/api/generate-text` に依存する自己PR生成機能

## ロールバック手順
- このコミットをリバートし、従来の `@google/generative-ai` ベース実装に戻す

## テスト結果
- 環境制約により依存関係が未取得のため以下コマンドが失敗
  - `pnpm install` (npm registry 403)
  - `pnpm test` (`vitest` not found)
  - `pnpm build` (`next` not found)
  - `pnpm lint` (`@eslint/eslintrc` not found)


------
https://chatgpt.com/codex/tasks/task_e_68db98e1b150832991233a0c717eed76