### PR TITLE
docs: refresh gemini migration guidance

### DIFF
--- a/docs/analyzeReceiptWithGemini.gs
+++ b/docs/analyzeReceiptWithGemini.gs
@@ -1,0 +1,76 @@
+/**
+ * Vertex AI Geminiを使って領収書画像を解析する関数。
+ * @param {GoogleAppsScript.Base.BlobSource} file 解析対象のファイル
+ * @param {string} projectId Vertex AIを有効にしたGCPプロジェクトID
+ * @param {string} prompt 入力プロンプト
+ * @param {string} [location="us-central1"] 利用するリージョン
+ * @returns {object} Geminiが返したJSONレスポンスをオブジェクト化したもの
+ */
+function analyzeReceiptWithGemini(file, projectId, prompt, location) {
+  if (!file) {
+    throw new Error('ファイルが指定されていません。');
+  }
+  if (!projectId) {
+    throw new Error('Vertex AI用のプロジェクトIDを指定してください。');
+  }
+  const targetLocation = location || 'us-central1';
+
+  // Apps Scriptの標準サービスアカウントでOAuth 2.0アクセストークンを取得し、APIキーの代わりに使用する。
+  const accessToken = ScriptApp.getOAuthToken();
+
+  const imageBlob = file.getBlob();
+  const base64Image = Utilities.base64Encode(imageBlob.getBytes());
+
+  const endpoint = `https://${targetLocation}-aiplatform.googleapis.com/v1/projects/${projectId}/locations/${targetLocation}/publishers/google/models/gemini-1.5-flash-002:generateContent`;
+
+  const payload = {
+    contents: [
+      {
+        role: 'user',
+        parts: [
+          { text: prompt },
+          {
+            inlineData: {
+              mimeType: imageBlob.getContentType(),
+              data: base64Image
+            }
+          }
+        ]
+      }
+    ],
+    generationConfig: {
+      responseMimeType: 'application/json'
+    }
+  };
+
+  const options = {
+    method: 'post',
+    contentType: 'application/json',
+    payload: JSON.stringify(payload),
+    muteHttpExceptions: true,
+    headers: {
+      Authorization: `Bearer ${accessToken}`
+    }
+  };
+
+  const response = UrlFetchApp.fetch(endpoint, options);
+  if (response.getResponseCode() !== 200) {
+    throw new Error(`Gemini APIリクエストエラー: ${response.getResponseCode()} ${response.getContentText()}`);
+  }
+
+  const result = JSON.parse(response.getContentText());
+  const candidate = result.candidates && result.candidates[0];
+  const part = candidate && candidate.content && candidate.content.parts && candidate.content.parts.find(function (p) {
+    return typeof p.text === 'string' && p.text.trim() !== '';
+  });
+
+  if (!part) {
+    throw new Error('Gemini APIから有効なテキストレスポンスが返されませんでした。');
+  }
+
+  try {
+    return JSON.parse(part.text);
+  } catch (error) {
+    throw new Error('GeminiのレスポンスをJSONとして解析できませんでした。');
+  }
+}

--- a/docs/gemini-analysis.md
+++ b/docs/gemini-analysis.md
@@ -1,0 +1,13 @@
+# Gemini API Migration Notes (2025-10)
+
+## Analysis & Recommendations
+- **認証方法**: 旧コードはURLにAPIキーを付与していましたが、2024年以降のVertex AI Generative AIではOAuth 2.0ベアラートークンによる認証が必須となり、APIキーでの呼び出しはサポート対象外です。Apps Scriptでは`ScriptApp.getOAuthToken()`で取得できるGCP連携サービスアカウントのアクセストークンをHTTPヘッダーに付与するのが推奨されています。
+- **APIエンドポイント**: `generativelanguage.googleapis.com` はスタンドアロンのGenerative Language API用であり、Vertex AI統合後のGemini商用利用では`{location}-aiplatform.googleapis.com`配下のVertex AIエンドポイントに切り替える必要があります。
+- **モデルIDとバージョン**: `gemini-1.5-flash-latest` は2025年10月時点で非推奨になっており、代わりに`gemini-1.5-flash-002`または`gemini-1.5-pro-002`が安定版として提供されています。`-latest` エイリアスは将来の後方互換性が保証されないため、明示的なモデルバージョンを指定します。
+- **リージョン**: Vertex AIの最新Geminiマルチモーダルモデルは`us-central1`や`us-east5`などの有効なロケーションを指定する必要があり、URLにリージョンセグメントを含めることが求められます。一般的な推奨は`us-central1`です。
+- **リクエストペイロード**: Vertex AIの`generateContent`では、`contents`配列の各要素に`role`を明示する必要があり、`parts`の順序もテキスト→画像の形で指定します。レスポンスは`candidates[].content.parts[].text`で返るため、安全なパース処理が必要です。
+
+## Corrected Google Apps Script Function
+- OAuth 2.0トークンで認証し、Vertex AIのエンドポイントへリクエストします。
+- 明示的なモデルIDとロケーションを引数で指定できるようにし、Apps Scriptの高度なエディタ設定でVertex AI APIを有効化しておくことを前提とします。
+- レスポンスがJSONで返らない場合の防御的なエラーハンドリングを追加します。

--- a/src/__tests__/gemini-docs.test.ts
+++ b/src/__tests__/gemini-docs.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('Gemini migration notes', () => {
+  it('documents the recommended model version explicitly', () => {
+    const doc = readFileSync(resolve(process.cwd(), 'docs/gemini-analysis.md'), 'utf8');
+    expect(doc).toContain('gemini-1.5-flash-002');
+  });
+});


### PR DESCRIPTION
## 目的
- Vertex AI移行後に非互換となったGemini呼び出し仕様を最新ドキュメントに沿って整理する
- Google Apps Script向けの動作例を提示し、既存レシート解析フローの復旧に備える

## 影響範囲
- ドキュメント読者およびApps ScriptでGeminiを呼ぶ補助機能
- 該当ノートの存在を確認する自動テスト

## 触るファイル
- docs/analyzeReceiptWithGemini.gs
- docs/gemini-analysis.md
- src/__tests__/gemini-docs.test.ts

## 変更点
- Gemini APIの最新要件に基づく移行ポイントを文書化
- Vertex AIエンドポイント向けのApps Script実装例を追加
- 推奨モデル記載を保証する簡易テストを追加

## テスト結果
- ⚠️ `pnpm install`（npm registry 403で失敗）
- ⚠️ `pnpm test`（依存未インストールによりvitestが見つからず失敗）
- ⚠️ `pnpm lint`（依存未インストールにより@eslint/eslintrc解決不可）
- ⚠️ `pnpm build`（依存未インストールによりnextが見つからず失敗）

## ロールバック手順
- `git revert f3c16da`


------
https://chatgpt.com/codex/tasks/task_e_68dc6ea3552883298d2a3e29687f54c3