### PR TITLE
chore: minimal Gemini 2.5 migration fixes (model, payload, error handling, env example)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Google AI Studio (Generative Language API)
+GEMINI_API_KEY=__REPLACE_WITH_YOUR_KEY__
+
+# Recommended model (2.5系)
+GEMINI_MODEL=gemini-2.5-flash
+
+# (将来) Provider switch : studio | vertex
+GEMINI_PROVIDER=studio
+
+# (将来) Vertex用。2.5系は global のみのモデルあり
+GOOGLE_LOCATION=global

--- a/REPORTS/gemini_migration_audit.json
+++ b/REPORTS/gemini_migration_audit.json
@@ -1,0 +1,113 @@
+{
+  "repo": "resume-builder-app",
+  "branch": "work",
+  "commit": "8df2a06f8e5175a2d46302f8913d91c53c7b9d47",
+  "summary": { "pass": 2, "warn": 1, "fail": 4 },
+  "findings": [
+    {
+      "id": "MODEL_VERSION",
+      "status": "fail",
+      "files": [
+        {
+          "path": "src/app/api/generate-text/route.js",
+          "line": 3,
+          "snippet": "const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent';"
+        },
+        {
+          "path": "src/app/api/generate-job/route.js",
+          "line": 6,
+          "snippet": "const MODEL = process.env.GOOGLE_GENAI_MODEL || 'gemini-1.5-flash';"
+        }
+      ],
+      "detail": "1.x 系モデル (gemini-pro, gemini-1.5-flash) を参照しており、2.5 系への移行が未対応。",
+      "recommendation": "環境変数とコードを更新して gemini-2.5-* モデルを使用し、旧モデルを除去する。"
+    },
+    {
+      "id": "REQUEST_FORMAT",
+      "status": "fail",
+      "files": [
+        {
+          "path": "src/app/api/generate-job/route.js",
+          "line": 68,
+          "snippet": "const result = await model.generateContent(prompt);"
+        }
+      ],
+      "detail": "SDK へ文字列のみを渡しており role/user の付与が保証されない。",
+      "recommendation": "generateContent 呼び出しで contents 配列と role: 'user' を明示し、400 を回避する。"
+    },
+    {
+      "id": "ENDPOINT_REGION",
+      "status": "pass",
+      "files": [
+        {
+          "path": "src/app/api/generate-text/route.js",
+          "line": 49,
+          "snippet": "const response = await fetch(`${GEMINI_API_URL}?key=${apiKey}`, {"
+        }
+      ],
+      "detail": "Studio API エンドポイント (generativelanguage.googleapis.com) を使用しており、リージョン指定の不整合は確認されない。",
+      "recommendation": "Vertex 経路追加時は locations/global を用いる。"
+    },
+    {
+      "id": "PROVIDER_SWITCH",
+      "status": "warn",
+      "files": [
+        {
+          "path": "src/app/api/generate-text/route.js",
+          "line": 41,
+          "snippet": "const apiKey = process.env.GEMINI_API_KEY;"
+        },
+        {
+          "path": "src/app/api/generate-job/route.js",
+          "line": 7,
+          "snippet": "const API_KEY =\n  process.env.GOOGLE_GENAI_API_KEY || process.env.GEMINI_API_KEY;"
+        }
+      ],
+      "detail": "Studio API キー経路に固定されており、Vertex との切替ができない。",
+      "recommendation": "GEMINI_PROVIDER 等で Studio/Vertex を切替できる抽象化を導入する。"
+    },
+    {
+      "id": "AUTHORIZATION",
+      "status": "pass",
+      "files": [
+        {
+          "path": "src/app/api/generate-text/route.js",
+          "line": 41,
+          "snippet": "const apiKey = process.env.GEMINI_API_KEY;"
+        },
+        {
+          "path": "src/app/api/generate-job/route.js",
+          "line": 7,
+          "snippet": "const API_KEY =\n  process.env.GOOGLE_GENAI_API_KEY || process.env.GEMINI_API_KEY;"
+        }
+      ],
+      "detail": "Studio API キーを参照し、未設定時にはエラーを返している。",
+      "recommendation": "Vertex 経路追加時は cloud-platform スコープの Bearer トークンを利用する。"
+    },
+    {
+      "id": "ERROR_HANDLING",
+      "status": "fail",
+      "files": [
+        {
+          "path": "src/app/api/generate-text/route.js",
+          "line": 66,
+          "snippet": "if (!response.ok) { ... return NextResponse.json({ error: 'AI文章の生成中にエラーが発生しました。' }, { status: 500 });"
+        },
+        {
+          "path": "src/app/api/generate-job/route.js",
+          "line": 83,
+          "snippet": "return NextResponse.json({ ok: false, ... error: e.message || 'server error' }, { status: 500 });"
+        }
+      ],
+      "detail": "HTTP ステータス別の診断が無く、404/403/400 の原因切り分けが困難。",
+      "recommendation": "レスポンスコードに応じたメッセージと再試行手順を実装する。"
+    },
+    {
+      "id": "ENV_CONFIGURATION",
+      "status": "fail",
+      "files": [],
+      "detail": "GEMINI_MODEL や GEMINI_PROVIDER などの推奨環境変数定義 (.env.example 等) が存在しない。",
+      "recommendation": "環境変数ファイルを整備し、2.5 系モデル・リージョン(global)・プロバイダー設定を明記する。"
+    }
+  ]
+}

--- a/REPORTS/gemini_migration_audit.md
+++ b/REPORTS/gemini_migration_audit.md
@@ -1,0 +1,68 @@
+# Gemini Migration Audit Report
+
+## 概要
+- 対象リポジトリ: resume-builder-app
+- ブランチ: work
+- コミット: 8df2a06f8e5175a2d46302f8913d91c53c7b9d47
+- 解析日時: $(TZ=Asia/Tokyo date '+%Y-%m-%d %H:%M %Z')
+
+## サマリ
+| 判定 | 件数 |
+| --- | --- |
+| Pass | 2 |
+| Warning | 1 |
+| Fail | 4 |
+
+## 詳細診断
+### MODEL_VERSION (Fail)
+- `src/app/api/generate-text/route.js` L3: `const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent';`
+  - 判定理由: gemini-pro (1.x系) がハードコードされており、2.5系モデルへの移行が未対応。
+  - 推奨対応: `gemini-2.5-flash` 等 2.5 系モデルを環境変数で指定し、API URL から 1.x 系モデルを除去する。
+- `src/app/api/generate-job/route.js` L6: `const MODEL = process.env.GOOGLE_GENAI_MODEL || 'gemini-1.5-flash';`
+  - 判定理由: デフォルトモデルとして gemini-1.5-flash を使用。EoL モデルに依存。
+  - 推奨対応: デフォルトを `gemini-2.5-flash` などに置き換え、環境変数も同様に更新する。
+
+### REQUEST_FORMAT (Fail)
+- `src/app/api/generate-job/route.js` L66-L69: `model.generateContent(prompt);`
+  - 判定理由: SDK へ文字列のみを渡しており、`contents: [{ role: 'user', parts: [...] }]` の形をアプリ側で強制していない。Role 欠落時の 400 を防止できない。
+  - 推奨対応: `model.generateContent({ contents: [{ role: 'user', parts: [{ text: prompt }] }] })` のように明示的に role/user を指定するヘルパーを実装する。
+
+### ENDPOINT_REGION (Pass)
+- `src/app/api/generate-text/route.js` L49: `fetch(...generativelanguage.googleapis.com...)`
+  - 判定理由: Studio 経路 (API key) を利用し、リージョン指定は不要。現状のリクエスト URI にリージョン不整合は見られない。
+
+### PROVIDER_SWITCH (Warning)
+- `src/app/api/generate-text/route.js` / `src/app/api/generate-job/route.js`
+  - 判定理由: Studio API キー経路のみ実装されており、Vertex への切替や抽象化レイヤーが存在しない。
+  - 推奨対応: `GEMINI_PROVIDER` 等の環境変数で Studio/Vertex を切り替えられる構造やインターフェース分離を設計する。
+
+### AUTHORIZATION (Pass)
+- `src/app/api/generate-text/route.js` L41-L45, `src/app/api/generate-job/route.js` L7-L58
+  - 判定理由: Studio 用の `GEMINI_API_KEY` / `GOOGLE_GENAI_API_KEY` を参照し、未設定時の検知も実装済み。Vertex 経路は未実装だが現状要件は満たす。
+
+### ERROR_HANDLING (Fail)
+- `src/app/api/generate-text/route.js` L66-L82
+  - 判定理由: 404/403/400 の原因別メッセージが無く、一律 500 応答。モデル名/リージョン誤りの自己診断が難しい。
+  - 推奨対応: `response.status` に応じて 404 (モデル/リージョン確認), 403 (請求やロール確認), 400 (リクエスト整形エラー) を個別案内するハンドリングを追加。
+- `src/app/api/generate-job/route.js` L83-L97
+  - 判定理由: エラー時は `e.message` のみ。外部要因 (403/404) と内部要因を判別できない。
+  - 推奨対応: Vertex/Studio のレスポンスコードに応じた診断メッセージと再試行案内を整備する。
+
+### ENV_CONFIGURATION (Fail)
+- `.env` 系ファイルが未整備。GEMINI_MODEL/GEMINI_PROVIDER/GOOGLE_LOCATION 等の推奨キーが定義されていない。
+  - 判定理由: 1.5 系モデル固定やリージョン未設定がコード側でも制御されておらず、デプロイ環境の再現性が低い。
+  - 推奨対応: `.env.example` などに `GEMINI_MODEL=gemini-2.5-flash`, `GEMINI_PROVIDER=studio`, `GOOGLE_LOCATION=global` 等を明記し、アプリ側でも参照する。
+
+## リスク/影響
+- 404: 1.x モデルを呼び続けると EoL 後に 404 が発生。ユーザーは生成結果を得られなくなり再試行しても改善しない。
+- 403: Vertex への移行時、ロール/請求未設定のままではアクセス拒否。現在の実装は指示を返さず調査が長期化するリスクが高い。
+- 400: `contents` 形式が保証されず、SDK 仕様変更時に role 欠落で 400 が発生する恐れ。ユーザーには汎用的な 500 エラーのみが表示され、原因追跡が困難。
+
+## 推奨アクション
+- 即時: モデル名を 2.5 系へ更新し、環境変数とコードを同期。
+- 短期: Request ペイロードの role/user 明示化とエラーコード別ハンドリングの実装。
+- 中期: Studio/Vertex のプロバイダー切替レイヤーを設計し、リージョンや認証方式を環境変数化。
+
+## 参考
+- 検索コマンド: `rg "gemini" -n`, `nl -ba src/app/api/generate-text/route.js`, `nl -ba src/app/api/generate-job/route.js`
+- コマンド履歴: `git status -sb`, `git rev-parse HEAD`

--- a/src/app/api/generate-job/route.js
+++ b/src/app/api/generate-job/route.js
@@ -3,7 +3,7 @@ import { GoogleGenerativeAI } from '@google/generative-ai';
 
 export const runtime = 'nodejs';
 
-const MODEL = process.env.GOOGLE_GENAI_MODEL || 'gemini-1.5-flash';
+const MODEL = process.env.GEMINI_MODEL || process.env.GOOGLE_GENAI_MODEL || 'gemini-2.5-flash';
 const API_KEY =
   process.env.GOOGLE_GENAI_API_KEY || process.env.GEMINI_API_KEY;
 
@@ -65,7 +65,14 @@ ${keywords || '（特になし）'}
 
     const genAI = new GoogleGenerativeAI(API_KEY);
     const model = genAI.getGenerativeModel({ model: MODEL });
-    const result = await model.generateContent(prompt);
+    const result = await model.generateContent({
+      contents: [
+        {
+          role: 'user',
+          parts: [{ text: String(prompt || '') }],
+        },
+      ],
+    });
     const text = result?.response?.text() ?? '';
 
     const summaryMatch = text.match(
@@ -83,6 +90,15 @@ ${keywords || '（特になし）'}
     return NextResponse.json({ ok: true, summary: summaryText, details: normalized });
   } catch (e) {
     console.error('generate-job error', e);
+    const status = Number(e?.status || e?.code || 500);
+    let message = e?.message || 'server error';
+    if (status === 400) {
+      message = 'リクエスト形式エラー（400）。contents/role の指定やパラメータを確認してください。';
+    } else if (status === 403) {
+      message = '認可エラー（403）。APIキーの権限・請求設定・利用制限を確認してください。';
+    } else if (status === 404) {
+      message = `モデル未検出（404）。MODEL=${MODEL} が有効か確認してください。`;
+    }
     return NextResponse.json(
       {
         ok: false,
@@ -91,10 +107,12 @@ ${keywords || '（特になし）'}
           company: c,
           detail: '',
         })),
-        error: e.message || 'server error',
+        error: message,
+        status,
       },
-      { status: 500 }
+      { status: Number.isFinite(status) ? status : 500 }
     );
   }
 }
+// TODO: Studio/Vertex の切替（GEMINI_PROVIDER）と GOOGLE_LOCATION=global の統一は将来対応
 

--- a/src/app/api/generate-text/route.js
+++ b/src/app/api/generate-text/route.js
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
-const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1/models/gemini-pro:generateContent';
+const MODEL = process.env.GEMINI_MODEL || 'gemini-2.5-flash';
+const GEMINI_API_URL = `https://generativelanguage.googleapis.com/v1/models/${MODEL}:generateContent`;
 
 const extractTextFromCandidates = (candidates = []) =>
   candidates
@@ -55,7 +56,7 @@ export async function POST(request) {
         contents: [
           {
             role: 'user',
-            parts: [{ text: prompt }],
+            parts: [{ text: String(prompt || '') }],
           },
         ],
       }),
@@ -64,11 +65,17 @@ export async function POST(request) {
     const payload = await response.json().catch(() => null);
 
     if (!response.ok) {
+      const status = response.status;
+      let message = 'AI文章の生成に失敗しました。';
+      if (status === 400) {
+        message = 'リクエスト形式エラー（400）。入力内容（contents/role）やトークン長を確認してください。';
+      } else if (status === 403) {
+        message = '認可エラー（403）。APIキー/請求設定/利用制限を確認してください。';
+      } else if (status === 404) {
+        message = `モデル未検出（404）。MODEL=${MODEL} が有効か、モデル名の綴りを確認してください。`;
+      }
       console.error('Gemini APIエラー:', payload?.error?.message ?? response.statusText);
-      return NextResponse.json(
-        { error: 'AI文章の生成中にエラーが発生しました。' },
-        { status: 500 }
-      );
+      return NextResponse.json({ error: message, status }, { status });
     }
 
     const generatedText = extractTextFromCandidates(payload?.candidates);
@@ -81,3 +88,4 @@ export async function POST(request) {
     return NextResponse.json({ error: 'AI文章の生成中にエラーが発生しました。' }, { status: 500 });
   }
 }
+// TODO: 将来的に Vertex 経路を追加する場合は GOOGLE_LOCATION=global と OAuth/Bearer トークン対応を実装


### PR DESCRIPTION
目的: Gemini移行監査のFail(MODEL_VERSION / REQUEST_FORMAT / ERROR_HANDLING / ENV_CONFIGURATION)を解消し、2.5系モデル利用とエラー診断強化を行う。
影響範囲: API Route Handler(`generate-text`, `generate-job`)のGemini呼び出し、環境変数サンプル。
触るファイル: src/app/api/generate-text/route.js, src/app/api/generate-job/route.js, .env.example

---
変更点:
- Geminiモデル名を環境変数(GEMINI_MODEL、既定 gemini-2.5-flash)で共通化し、1.x固定値を排除。
- generateContent呼び出しを `contents -> role: 'user'` 形式に統一し、400/403/404に応じた診断メッセージを返却。
- `.env.example` を追加し、推奨環境変数とデフォルト設定、Studio/Vertex切替TODOを明記。
- TODOコメントで将来のVertex対応(リージョン=global, OAuth/Bearer)を指示。

ロールバック手順:
- これらのファイルを前コミットに戻すか、`git revert` で本PRのコミットを取り消す。

テスト結果:
- `pnpm install` : ❌ registry 403 (外部ネットワーク制限により依存取得不可)
- `pnpm build` : ❌ `next: not found` (node_modules未構築のため)
- `pnpm test` : ❌ `vitest: not found` (node_modules未構築のため)
- `pnpm lint` : ❌ `@eslint/eslintrc` 解決不可 (node_modules未構築のため)

Closes audit findings: MODEL_VERSION / REQUEST_FORMAT / ERROR_HANDLING / ENV_CONFIGURATION

新規ファイル `.env.example` 追加理由: Vercel等の環境で推奨変数を明示し、GEMINI_MODEL=gemini-2.5-flash など移行必須設定を共有するため。配置はリポジトリルート。


------
https://chatgpt.com/codex/tasks/task_e_68dc8be972b48329906c2935ef4c8175